### PR TITLE
Bump version with changes for reading new node

### DIFF
--- a/lib/cfdi_processor/version.rb
+++ b/lib/cfdi_processor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CfdiProcessor
-  VERSION = '1.1.1'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
I considered reading a new node as a new feature that is why I put 1.2.0